### PR TITLE
Change category in ext_emconf.php

### DIFF
--- a/packages/site_example/ext_emconf.php
+++ b/packages/site_example/ext_emconf.php
@@ -2,7 +2,7 @@
 $EM_CONF[$_EXTKEY] = array(
   'title' => 'Site Example',
   'description' => 'Site package example',
-  'category' => 'Example Extensions',
+  'category' => 'templates',
   'author' => 'Helmut Hummel',
   'author_email' => 'info@helhum.io',
   'author_company' => 'helhum.io',


### PR DESCRIPTION
According to the documentation on https://docs.typo3.org/typo3cms/CoreApiReference/ExtensionArchitecture/DeclarationFile/Index.html, "Example Extensions" doesn't seem to be a valid value for category. I propose to use "templates".